### PR TITLE
BUG: normalize Discourse tags to strings in blog loader

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -55,7 +55,7 @@ const blogLoader = async () => {
         id: "" + post.id,
         slug: post.slug,
         title: post.title,
-        tags: post.tags,
+        tags: (post.tags || []).map((t) => (typeof t === 'string' ? t : t.slug ?? t.name)),
         publishDate: new Date(post.created_at),
         content
       }


### PR DESCRIPTION
Discourse's topic_list API returns tags as {id, name, slug} objects rather than plain strings, which breaks cleanSlug (trimSlash(obj).split is not a function) during RSS generation.

Noticed when an empty commit pushed to trigger a Cloudflare Pages rebuild (to pull in new forum content) failed the build.